### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ on: [push]
 jobs:
     tests:
         runs-on: ubuntu-latest
-
+        strategy:
+            matrix:
+              php-versions: ['7.4', '8.0']
         steps:
             - name: Checkout
               uses: actions/checkout@v1
@@ -13,7 +15,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v1
               with:
-                  php-version: '7.4'
+                  php-version: ${{ matrix.php-versions }}
                   extensions: mbstring, intl
 
             - name: Install Dependencies

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "ext-libxml": "*",
         "ext-xmlreader": "*"
     },


### PR DESCRIPTION
# Changes

 - PHP 8.0 is now allowed in composer.json
 - CI is updated to run on both 7.4 and 8.0
 
 No code changes were needed